### PR TITLE
Fixes N+1 problem for getTotalStats and improved performance

### DIFF
--- a/api/app/Player.php
+++ b/api/app/Player.php
@@ -5,6 +5,7 @@ namespace App;
 use App\TeamPlayer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Player extends Model
 {
@@ -18,5 +19,45 @@ class Player extends Model
     public function teamPlayers(): HasMany
     {
         return $this->hasMany(TeamPlayer::class, 'player_id', 'id');
+    }
+
+    /**
+     * Team relationship
+     *
+     * @return HasManyThrough
+     *
+     * @author Roy Freij <info@royfreij.nl>
+     * @version 1.0.0
+     */
+    public function teams(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            Team::class,
+            TeamPlayer::class,
+            'player_id',
+            'id',
+            'id',
+            'team_id'
+        );
+    }
+
+    /**
+     * results relationship
+     *
+     * @return HasManyThrough
+     *
+     * @author Roy Freij <info@royfreij.nl>
+     * @version 1.0.0
+     */
+    public function results(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            Result::class,
+            TeamPlayer::class,
+            'player_id',
+            'team_id',
+            'id',
+            'team_id'
+        );
     }
 }


### PR DESCRIPTION
This will fix a minor N+1 problem for getTotalStats, and slightly improve performance 

Request time & queries before fix
![Screenshot from 2019-08-11 15-35-54](https://user-images.githubusercontent.com/15109384/62834750-0a23c500-bc51-11e9-8935-da8460a2972b.png)
![Screenshot from 2019-08-11 15-36-28](https://user-images.githubusercontent.com/15109384/62834752-10b23c80-bc51-11e9-856e-dbdaa8453ce9.png)

Request time & queries after fix
![image](https://user-images.githubusercontent.com/15109384/62835021-eada6700-bc53-11e9-8b31-62370ba39543.png)

![Screenshot from 2019-08-11 15-36-54](https://user-images.githubusercontent.com/15109384/62834755-19a30e00-bc51-11e9-94a9-4ebc8d5e3aa1.png)

I could have calculated the amount of matches won and lost by using Laravel's collection method filter to, but i've noticed a decrease in performance of about 100ms when doing that seperately instead of in one foreach so i kept that as-is.

I couldn't use the join for team2 score anymore because of the with for some reason. Laravel just didn't add it in the results. Also that join decreased performance more then the added `with(['event.results'])`