### PR TITLE
Feature/get duo stats improvements

### DIFF
--- a/angular/src/app/pages/dashboard/dashboard.component.ts
+++ b/angular/src/app/pages/dashboard/dashboard.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
+import { ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-dashboard',
@@ -13,7 +14,7 @@ export class DashboardComponent implements OnInit {
     public loading = false;
     public amountOfResults = 0;
     public events = [];
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
 
     constructor(private httpService: HttpService) {}
 

--- a/angular/src/app/pages/match/match.component.ts
+++ b/angular/src/app/pages/match/match.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
+import { ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-match',
@@ -9,7 +10,7 @@ import { HttpService } from 'src/app/services/http.service';
 export class MatchComponent implements OnInit {
     public loading = false;
     public selectedMatchType = 'random';
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
     public users: any;
     public matchTypes: { name: string; code_name: string }[];
     public matchPlayers: {}[];

--- a/angular/src/app/pages/players/players.component.ts
+++ b/angular/src/app/pages/players/players.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
+import { ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-players',
@@ -8,7 +9,7 @@ import { HttpService } from 'src/app/services/http.service';
 })
 export class PlayersComponent implements OnInit {
     public loading = false;
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
     public users: any;
     public player: any;
 

--- a/angular/src/app/pages/results/results.component.ts
+++ b/angular/src/app/pages/results/results.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
 import { ActivatedRoute } from '@angular/router';
+import { ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-results',
@@ -18,7 +19,7 @@ export class ResultsComponent implements OnInit {
     public team1Name = '';
     public team2Name = '';
     public results: any = {};
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
 
     constructor(
         private httpService: HttpService,

--- a/angular/src/app/pages/standings/standings.component.html
+++ b/angular/src/app/pages/standings/standings.component.html
@@ -51,17 +51,17 @@
                         <th>Kruipscore</th>
                         <th>Gemiddelde kruipscore</th>
                     </thead>
-                    <tr *ngFor="let team of data | keyvalue; let i = index">
+                    <tr *ngFor="let team of data; let i = index">
                         <td>{{ i + 1 }}</td>
-                        <td>{{ team.value.name }}</td>
-                        <td>{{ team.value.totalgames }}</td>
-                        <td>{{ team.value.won }}</td>
-                        <td>{{ team.value.lost }}</td>
-                        <td>{{ team.value.winlose }}</td>
-                        <td>{{ team.value.totalscore }}</td>
-                        <td>{{ team.value.avgscore }}/match</td>
-                        <td>{{ team.value.crawlscore }}</td>
-                        <td>{{ team.value.avgcrawlscore }}/match</td>
+                        <td>{{ team.name }}</td>
+                        <td>{{ team.totalgames }}</td>
+                        <td>{{ team.won }}</td>
+                        <td>{{ team.lost }}</td>
+                        <td>{{ team.winlose }}</td>
+                        <td>{{ team.totalscore }}</td>
+                        <td>{{ team.avgscore }}/match</td>
+                        <td>{{ team.crawlscore }}</td>
+                        <td>{{ team.avgcrawlscore }}/match</td>
                     </tr>
                 </table>
 

--- a/angular/src/app/pages/standings/standings.component.html
+++ b/angular/src/app/pages/standings/standings.component.html
@@ -51,17 +51,17 @@
                         <th>Kruipscore</th>
                         <th>Gemiddelde kruipscore</th>
                     </thead>
-                    <tr *ngFor="let team of data; let i = index">
+                    <tr *ngFor="let team of data | keyvalue; let i = index">
                         <td>{{ i + 1 }}</td>
-                        <td>{{ team.name }}</td>
-                        <td>{{ team.totalgames }}</td>
-                        <td>{{ team.won }}</td>
-                        <td>{{ team.lost }}</td>
-                        <td>{{ team.winlose }}</td>
-                        <td>{{ team.totalscore }}</td>
-                        <td>{{ team.avgscore }}/match</td>
-                        <td>{{ team.crawlscore }}</td>
-                        <td>{{ team.avgcrawlscore }}/match</td>
+                        <td>{{ team.value.name }}</td>
+                        <td>{{ team.value.totalgames }}</td>
+                        <td>{{ team.value.won }}</td>
+                        <td>{{ team.value.lost }}</td>
+                        <td>{{ team.value.winlose }}</td>
+                        <td>{{ team.value.totalscore }}</td>
+                        <td>{{ team.value.avgscore }}/match</td>
+                        <td>{{ team.value.crawlscore }}</td>
+                        <td>{{ team.value.avgcrawlscore }}/match</td>
                     </tr>
                 </table>
 

--- a/angular/src/app/pages/standings/standings.component.ts
+++ b/angular/src/app/pages/standings/standings.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
+import { DuoStats, ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-standings',
@@ -7,9 +8,7 @@ import { HttpService } from 'src/app/services/http.service';
     styleUrls: ['./standings.component.scss'],
 })
 export class StandingsComponent implements OnInit {
-    public totals = [];
-    public playerStats = [];
-    public data: any;
+    public data: DuoStats[] = [];
 
     public periodFilter = 'all-time';
     public periods = [
@@ -89,7 +88,7 @@ export class StandingsComponent implements OnInit {
         },
     ];
 
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
 
     constructor(private httpService: HttpService) {}
 
@@ -107,20 +106,14 @@ export class StandingsComponent implements OnInit {
      * @param newSort the new sort option
      */
     public getDuoStats(newPeriod: string, newSort: string): void {
-        // reset
-        this.totals = [];
-        // make request
         this.periodFilter = newPeriod;
         this.sortFilter = newSort;
         this.httpService
             .get(`standings/duo/${this.periodFilter}/${this.sortFilter}`)
             .subscribe(
-                (data: ApiResponse) => {
+                (data: ApiResponse<DuoStats>) => {
                     if (data.msg === undefined) {
-                        this.data = data;
-                        for (const stat of this.data) {
-                            this.totals.push(stat);
-                        }
+                        this.data = data.data;
                     } else {
                         this.resResult.error = true;
                         this.resResult.msg = data.msg;
@@ -128,7 +121,7 @@ export class StandingsComponent implements OnInit {
                 },
                 error => console.error(error),
                 () => {
-                    if (this.totals.length > 0) {
+                    if (this.data.length > 0) {
                         this.resResult = {};
                     }
                 }

--- a/angular/src/app/pages/standings/standings.component.ts
+++ b/angular/src/app/pages/standings/standings.component.ts
@@ -54,12 +54,12 @@ export class StandingsComponent implements OnInit {
         {
             id: 1,
             name: 'Gewonnen',
-            code: 'win',
+            code: 'won',
         },
         {
             id: 2,
             name: 'Verloren',
-            code: 'lose',
+            code: 'lost',
         },
         {
             id: 3,
@@ -74,17 +74,17 @@ export class StandingsComponent implements OnInit {
         {
             id: 5,
             name: 'Teamscore',
-            code: 'score',
+            code: 'totalscore',
         },
         {
             id: 6,
             name: 'Gemiddelde kruipscore',
-            code: 'avgcrawl',
+            code: 'avgcrawlscore',
         },
         {
             id: 7,
             name: 'Kruipscore',
-            code: 'crawl',
+            code: 'crawlscore',
         },
     ];
 

--- a/angular/src/app/pages/statistics/statistics.component.ts
+++ b/angular/src/app/pages/statistics/statistics.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpService } from 'src/app/services/http.service';
+import { ApiResponse } from 'src/app/types/api-response';
 
 @Component({
     selector: 'app-statistics',
@@ -173,7 +174,7 @@ export class StatisticsComponent implements OnInit {
     public orderByDefault = 19;
     public orderBy = this.orderOptions[19];
     public statsLimit = 40;
-    public resResult: ApiResponse = {};
+    public resResult: ApiResponse<void> = {};
 
     constructor(private httpService: HttpService) {}
 

--- a/angular/src/app/types/api-response.ts
+++ b/angular/src/app/types/api-response.ts
@@ -1,6 +1,19 @@
-type ApiResponse = {
+export type ApiResponse<T> = {
     error?: boolean;
     msg?: string;
     success?: boolean;
     errors?: object[];
+    data?: T[];
 };
+
+export interface DuoStats {
+    avgcrawlscore: number;
+    avgscore: number;
+    crawlscore: number;
+    lost: number;
+    name: string;
+    totalgames: number;
+    totalscore: number;
+    winlose: number;
+    won: number;
+}

--- a/api/app/Http/Controllers/StatsController.php
+++ b/api/app/Http/Controllers/StatsController.php
@@ -372,8 +372,10 @@ class StatsController extends Controller
         }
 
         if (in_array($sort, $sortOptions)) {
-            $data = $data->sortByDesc($sort)->values();
+            $data = $data->sortByDesc($sort);
         }
+
+        $data = $data->values();
 
         return new JsonResponse([
             'data' => $data->toArray(),


### PR DESCRIPTION
This pull request main goal is to refactor the getDuoStats method a bit and add better typesupport for that request. 

The period 'yesterday' was still missing so i've added it. 

The change that is worth to notice as well is this one:
```
if (!$periodSet && $stats->totalgames < 6) {
    continue;
}
```

I've added the check of !$periodSet since when selecting a period where there aren't enough matches it just returned an empty array. I think this is unexpected behaviour and so i think it's best to only filter on total games when not selecting a period. 

I will be looking into better type support for the client side next